### PR TITLE
fix: update import path for styles in Storybook preview

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,5 @@
 import type { Preview } from "@storybook/react";
-import "../src/index.css";
+import "../src/styles.css";
 import { ToastProvider } from "../src/lib/components/Toast";
 import React from "react";
 import { withThemeByClassName } from "@storybook/addon-themes";


### PR DESCRIPTION
This pull request updates the `.storybook/preview.ts` file to reflect a change in the CSS import path, ensuring the correct stylesheet is loaded for the Storybook environment.

* [`.storybook/preview.ts`](diffhunk://#diff-d42715fd3297e575fb61faba39bba1b83739d3fd533a719ccfb0d81f64862b15L2-R2): Replaced the import of `../src/index.css` with `../src/styles.css` to use the updated stylesheet.