### PR TITLE
Potential fix for code scanning alert no. 2: Expression injection in Actions

### DIFF
--- a/.github/workflows/publish-and-deploy.yml
+++ b/.github/workflows/publish-and-deploy.yml
@@ -40,11 +40,13 @@ jobs:
     steps:
       - name: Check commit message
         id: check_commit
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          if [[ "${{ github.event.head_commit.message }}" == *"chore: bump version"* ]]; then
+          if [[ "$COMMIT_MESSAGE" == *"chore: bump version"* ]]; then
             echo "Skip workflow for version bump commits"
             echo "skip=true" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event.head_commit.message }}" == *"chore: bump MCP server version"* ]]; then
+          elif [[ "$COMMIT_MESSAGE" == *"chore: bump MCP server version"* ]]; then
             echo "Skip workflow for standalone MCP version bump commits"
             echo "skip=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Potential fix for [https://github.com/akitectio/aki-ui/security/code-scanning/2](https://github.com/akitectio/aki-ui/security/code-scanning/2)

To fix the issue, the commit message should be assigned to an intermediate environment variable and referenced using native shell syntax (`$VAR`) instead of expression syntax (`${{ env.VAR }}`). This approach ensures that the input is treated as plain text and prevents command injection.

**Steps to fix:**
1. Assign the `github.event.head_commit.message` to an environment variable.
2. Use the environment variable in the shell script with native shell syntax (`$VAR`).
3. Ensure that the environment variable is properly quoted to prevent unintended behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
